### PR TITLE
186 fix dotnet migrations

### DIFF
--- a/ch03/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
+++ b/ch03/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
   </ItemGroup>
   

--- a/ch03/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
+++ b/ch03/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -16,6 +16,14 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Codebreaker.GameAPIs.Models\Codebreaker.GameAPIs.Models.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="GamesSqlServerContextFactory.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <Compile Include="GamesSqlServerContextFactory.cs" />
   </ItemGroup>
 
 </Project>

--- a/ch03/Codebreaker.Data.SqlServer/GamesSqlServerContextFactory.cs
+++ b/ch03/Codebreaker.Data.SqlServer/GamesSqlServerContextFactory.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore.Design;
+
+namespace Codebreaker.Data.SqlServer;
+
+public class GamesSqlServerContextFactory : IDesignTimeDbContextFactory<GamesSqlServerContext>
+{
+    public GamesSqlServerContext CreateDbContext(string[] args)
+    {
+        if (args.Length != 1)
+        {
+            throw new InvalidOperationException("Usage: dotnet ef migrations add <Name> -- <connectionString>");
+        }
+        string connectionString = args[0];
+        var optionsBuilder = new DbContextOptionsBuilder<GamesSqlServerContext>();
+        optionsBuilder.UseSqlServer(connectionString);
+        return new GamesSqlServerContext(optionsBuilder.Options);
+    }
+}

--- a/ch03/Readme.md
+++ b/ch03/Readme.md
@@ -1,4 +1,4 @@
-# Chapter 3
+# Chapter 3 - Writing data to relational and NoSQL databases
 
 ## Technical requirements
 
@@ -76,3 +76,17 @@ Make sure the app model in the App Host has the correct configuration - either u
 
 * [Components diagram](components.drawio)
 * [Create a game using SQL Server](CreateAGameWithSQLServer.md)
+
+## Updates
+
+Using `dotnet ef migrations` fails referencing the games API startup project because the EF Core configuration is now in `ApplicationServices` instead of the `Program.cs`, and thus cannot be found from the `dotnet ef` tool.
+
+See the different options to create the context at design time: [Design-time DbContext Creation](https://learn.microsoft.com/en-us/ef/core/cli/dbcontext-creation)
+
+I added the `GamesSqlServerContextFactory` class to the SQL Server library which can be used this way to create a new migration:
+
+```bash
+dotnet ef migrations add <Name> -- "server=(localdb)\mssqllocaldb;database=Test;trusted_connection=true"
+```
+
+A connection string to the database needs to be passed following `--` which is read with arguments from the `GamesSqlServerContextFactory`.

--- a/ch03/Readme.md
+++ b/ch03/Readme.md
@@ -86,6 +86,7 @@ See the different options to create the context at design time: [Design-time DbC
 I added the `GamesSqlServerContextFactory` class to the SQL Server library which can be used this way to create a new migration:
 
 ```bash
+cd Codebreaker.Data.SqlServer
 dotnet ef migrations add <Name> -- "server=(localdb)\mssqllocaldb;database=Test;trusted_connection=true"
 ```
 


### PR DESCRIPTION
Allow creating migrations without referencing the startup project