### PR TITLE
Aspire 8.1 updates ch05

### DIFF
--- a/ch05/FinalAspire/CodeBreaker.Bot.Tests/CodeBreaker.Bot.Tests.csproj
+++ b/ch05/FinalAspire/CodeBreaker.Bot.Tests/CodeBreaker.Bot.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ch05/FinalAspire/CodeBreaker.Bot/CodeBreaker.Bot.csproj
+++ b/ch05/FinalAspire/CodeBreaker.Bot/CodeBreaker.Bot.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ch05/FinalAspire/Codebreaker.AppHost/Codebreaker.AppHost.csproj
+++ b/ch05/FinalAspire/Codebreaker.AppHost/Codebreaker.AppHost.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/ch05/FinalAspire/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
+++ b/ch05/FinalAspire/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.1" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="8.1.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.1.0" />
     <PackageReference Include="CNinnovation.Codebreaker.Cosmos" Version="3.7.0" />
     <PackageReference Include="CNinnovation.Codebreaker.SqlServer" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ch05/FinalAspire/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch05/FinalAspire/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -54,12 +54,12 @@ public class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger) : IGam
 
         if (gamesQuery.RunningOnly)
         {
-            filteredGames = filteredGames.Where(g => !g.Ended());
+            filteredGames = filteredGames.Where(g => !g.HasEnded());
         }
 
         if (gamesQuery.Ended)
         {
-            filteredGames = filteredGames.Where(g => g.Ended());
+            filteredGames = filteredGames.Where(g => g.HasEnded());
         }
 
         return Task.FromResult(filteredGames);

--- a/ch05/FinalAspire/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
+++ b/ch05/FinalAspire/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
@@ -13,8 +13,8 @@ public static partial class ApiModelExtensions
         };
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game, string[] result) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, result);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, result);
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, null);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, null);
 }

--- a/ch05/FinalAspire/Codebreaker.ServiceDefaults/Codebreaker.ServiceDefaults.csproj
+++ b/ch05/FinalAspire/Codebreaker.ServiceDefaults/Codebreaker.ServiceDefaults.csproj
@@ -11,14 +11,14 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.6.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/FinalDocker/CodeBreaker.Bot/CodeBreaker.Bot.csproj
+++ b/ch05/FinalDocker/CodeBreaker.Bot/CodeBreaker.Bot.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/FinalDocker/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
+++ b/ch05/FinalDocker/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
@@ -12,11 +12,11 @@
   <ItemGroup>
     <PackageReference Include="CNinnovation.Codebreaker.Cosmos" Version="3.7.0" />
     <PackageReference Include="CNinnovation.Codebreaker.SqlServer" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/FinalDocker/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch05/FinalDocker/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -54,12 +54,12 @@ public class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger) : IGam
 
         if (gamesQuery.RunningOnly)
         {
-            filteredGames = filteredGames.Where(g => !g.Ended());
+            filteredGames = filteredGames.Where(g => !g.HasEnded());
         }
 
         if (gamesQuery.Ended)
         {
-            filteredGames = filteredGames.Where(g => g.Ended());
+            filteredGames = filteredGames.Where(g => g.HasEnded());
         }
 
         return Task.FromResult(filteredGames);

--- a/ch05/FinalDocker/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
+++ b/ch05/FinalDocker/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
@@ -13,8 +13,8 @@ public static partial class ApiModelExtensions
         };
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game, string[] result) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, result);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, result);
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, null);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, null);
 }

--- a/ch05/NativeAOT/Codebreaker.GameAPIs.NativeAOT/Codebreaker.GameAPIs.NativeAOT.csproj
+++ b/ch05/NativeAOT/Codebreaker.GameAPIs.NativeAOT/Codebreaker.GameAPIs.NativeAOT.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="CNinnovation.Codebreaker.BackendModels" Version="3.7.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/StartAspire/CodeBreaker.Bot.Tests/CodeBreaker.Bot.Tests.csproj
+++ b/ch05/StartAspire/CodeBreaker.Bot.Tests/CodeBreaker.Bot.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ch05/StartAspire/CodeBreaker.Bot/CodeBreaker.Bot.csproj
+++ b/ch05/StartAspire/CodeBreaker.Bot/CodeBreaker.Bot.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ch05/StartAspire/Codebreaker.AppHost/Codebreaker.AppHost.csproj
+++ b/ch05/StartAspire/Codebreaker.AppHost/Codebreaker.AppHost.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="8.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/ch05/StartAspire/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
+++ b/ch05/StartAspire/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.1" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="8.1.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.1.0" />
     <PackageReference Include="CNinnovation.Codebreaker.Cosmos" Version="3.7.0" />
     <PackageReference Include="CNinnovation.Codebreaker.SqlServer" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ch05/StartAspire/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch05/StartAspire/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -54,12 +54,12 @@ public class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger) : IGam
 
         if (gamesQuery.RunningOnly)
         {
-            filteredGames = filteredGames.Where(g => !g.Ended());
+            filteredGames = filteredGames.Where(g => !g.HasEnded());
         }
 
         if (gamesQuery.Ended)
         {
-            filteredGames = filteredGames.Where(g => g.Ended());
+            filteredGames = filteredGames.Where(g => g.HasEnded());
         }
 
         return Task.FromResult(filteredGames);

--- a/ch05/StartAspire/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
+++ b/ch05/StartAspire/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
@@ -13,8 +13,8 @@ public static partial class ApiModelExtensions
         };
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game, string[] result) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, result);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, result);
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, null);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, null);
 }

--- a/ch05/StartAspire/Codebreaker.ServiceDefaults/Codebreaker.ServiceDefaults.csproj
+++ b/ch05/StartAspire/Codebreaker.ServiceDefaults/Codebreaker.ServiceDefaults.csproj
@@ -11,14 +11,14 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.6.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/StartDocker/CodeBreaker.Bot/CodeBreaker.Bot.csproj
+++ b/ch05/StartDocker/CodeBreaker.Bot/CodeBreaker.Bot.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <!--<PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.6.0-beta.19" />-->
     <PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/StartDocker/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
+++ b/ch05/StartDocker/Codebreaker.GameAPIs/Codebreaker.GameAPIs.csproj
@@ -11,10 +11,10 @@
   <ItemGroup>
     <PackageReference Include="CNinnovation.Codebreaker.Cosmos" Version="3.7.0" />
     <PackageReference Include="CNinnovation.Codebreaker.SqlServer" Version="3.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
   </ItemGroup>
 
 </Project>

--- a/ch05/StartDocker/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch05/StartDocker/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -54,12 +54,12 @@ public class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger) : IGam
 
         if (gamesQuery.RunningOnly)
         {
-            filteredGames = filteredGames.Where(g => !g.Ended());
+            filteredGames = filteredGames.Where(g => !g.HasEnded());
         }
 
         if (gamesQuery.Ended)
         {
-            filteredGames = filteredGames.Where(g => g.Ended());
+            filteredGames = filteredGames.Where(g => g.HasEnded());
         }
 
         return Task.FromResult(filteredGames);

--- a/ch05/StartDocker/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
+++ b/ch05/StartDocker/Codebreaker.GameAPIs/Extensions/ApiModelExtensions.cs
@@ -13,8 +13,8 @@ public static partial class ApiModelExtensions
         };
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game, string[] result) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, result);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, result);
 
     public static UpdateGameResponse ToUpdateGameResponse(this Game game) =>
-        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.Ended(), game.IsVictory, null);
+        new(game.Id, Enum.Parse<GameType>(game.GameType), game.LastMoveNumber, game.HasEnded(), game.IsVictory, null);
 }


### PR DESCRIPTION
#### PR Classification
Dependency updates and method refactoring.

#### PR Summary
Updated package references and refactored method calls for consistency and latest features.
- Updated various package references across multiple project files, including `xunit`, `Microsoft.AspNetCore.OpenApi`, and `Swashbuckle.AspNetCore`.
- Modified method calls in `GamesMemoryRepository.cs` and `ApiModelExtensions.cs` to replace `Ended()` with `HasEnded()`.
- Updated `Aspire.Hosting` and related packages in `Codebreaker.AppHost.csproj` and `Codebreaker.GameAPIs.csproj`.
- Updated `Microsoft.Extensions.Http.Resilience` and `Microsoft.Extensions.ServiceDiscovery` in `Codebreaker.ServiceDefaults.csproj`.
- Ensured consistency in package versions across different project files.
