### PR TITLE
Fix missing updates to UTC 

### DIFF
--- a/ch02/Codebreaker.GameAPIs/Services/GamesFactory.cs
+++ b/ch02/Codebreaker.GameAPIs/Services/GamesFactory.cs
@@ -21,7 +21,7 @@ public static class GamesFactory
     public static Game CreateGame(string gameType, string playerName)
     {
         Game Create6x4SimpleGame() =>
-            new(Guid.NewGuid(), gameType, playerName,  DateTime.Now, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName,  DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -31,7 +31,7 @@ public static class GamesFactory
             };
 
         Game Create6x4Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -41,7 +41,7 @@ public static class GamesFactory
             };
 
         Game Create8x5Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 5, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 5, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -51,7 +51,7 @@ public static class GamesFactory
             };
 
         Game Create5x5x4Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 4, 14)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 14)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {

--- a/ch02/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch02/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -41,7 +41,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch03/Codebreaker.GameAPIs/Services/GamesFactory.cs
+++ b/ch03/Codebreaker.GameAPIs/Services/GamesFactory.cs
@@ -21,7 +21,7 @@ public static class GamesFactory
     public static Game CreateGame(string gameType, string playerName)
     {
         Game Create6x4SimpleGame() =>
-            new(Guid.NewGuid(), gameType, playerName,  DateTime.Now, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -31,7 +31,7 @@ public static class GamesFactory
             };
 
         Game Create6x4Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -41,7 +41,7 @@ public static class GamesFactory
             };
 
         Game Create8x5Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 5, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 5, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -51,7 +51,7 @@ public static class GamesFactory
             };
 
         Game Create5x5x4Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 4, 14)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 14)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {

--- a/ch03/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch03/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch04/server/Codebreaker.GameAPIs/Services/GamesFactory.cs
+++ b/ch04/server/Codebreaker.GameAPIs/Services/GamesFactory.cs
@@ -21,7 +21,7 @@ public static class GamesFactory
     public static Game CreateGame(string gameType, string playerName)
     {
         Game Create6x4SimpleGame() =>
-            new(Guid.NewGuid(), gameType, playerName,  DateTime.Now, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -31,7 +31,7 @@ public static class GamesFactory
             };
 
         Game Create6x4Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -41,7 +41,7 @@ public static class GamesFactory
             };
 
         Game Create8x5Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 5, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 5, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {
@@ -51,7 +51,7 @@ public static class GamesFactory
             };
 
         Game Create5x5x4Game() =>
-            new(Guid.NewGuid(), gameType, playerName, DateTime.Now, 4, 14)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 14)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {

--- a/ch04/server/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch04/server/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch05/FinalAspire/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch05/FinalAspire/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch05/FinalDocker/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch05/FinalDocker/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch05/NativeAOT/Codebreaker.GameAPIs.NativeAOT/Services/GamesService.cs
+++ b/ch05/NativeAOT/Codebreaker.GameAPIs.NativeAOT/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch05/StartAspire/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch05/StartAspire/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch05/StartDocker/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch05/StartDocker/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch06/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch06/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch07/Codebreaker.GameAPIs/Services/GamesFactory.cs
+++ b/ch07/Codebreaker.GameAPIs/Services/GamesFactory.cs
@@ -21,7 +21,7 @@ public static class GamesFactory
     public static Game CreateGame(string gameType, string playerName)
     {
         Game Create6x4SimpleGame() =>
-            new(Guid.NewGuid(), gameType, playerName,  DateTime.UtcNow, 4, 12)
+            new(Guid.NewGuid(), gameType, playerName, DateTime.UtcNow, 4, 12)
             {
                 FieldValues = new Dictionary<string, IEnumerable<string>>()
                 {

--- a/ch07/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch07/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch08/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch08/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch09/Codebreaker.GameAPIs/Services/GamesService.cs
+++ b/ch09/Codebreaker.GameAPIs/Services/GamesService.cs
@@ -42,7 +42,7 @@ public class GamesService(IGamesRepository dataRepository) : IGamesService
         Game? game = await dataRepository.GetGameAsync(id, cancellationToken);
         CodebreakerException.ThrowIfNull(game);
        
-        game.EndTime = DateTime.Now;
+        game.EndTime = DateTime.UtcNow;
         game.Duration = game.EndTime - game.StartTime;
         game = await dataRepository.UpdateGameAsync(game, cancellationToken);
         return game;

--- a/ch10/Final/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch10/Final/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -13,17 +13,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch11/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch11/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -18,17 +18,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch12/CodeBreaker.Blazor/Pages/GamePage.razor.cs
+++ b/ch12/CodeBreaker.Blazor/Pages/GamePage.razor.cs
@@ -59,7 +59,7 @@ public sealed partial class GamePage : IDisposable
             _loadingGame = true;
             _gameStatus = GameMode.NotRunning;
             (Guid gameId, int numberCodes, int maxMoves, IDictionary<string, string[]> fieldValues) = await Client.StartGameAsync(_selectedGameType, _name);
-            _game = new(gameId, _selectedGameType.ToString(), _name, DateTime.Now, numberCodes, maxMoves)
+            _game = new(gameId, _selectedGameType.ToString(), _name, DateTime.UtcNow, numberCodes, maxMoves)
             {
                 FieldValues = fieldValues.ToDictionary(x => x.Key, x => x.Value.AsEnumerable()),
                 Codes = []

--- a/ch12/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch12/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -20,17 +20,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch12/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch12/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -84,7 +84,7 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
 
     private Task CleanupOldGamesAsync()
     {
-        if (_lastCleanupRun > DateTime.Now.AddHours(-1))
+        if (_lastCleanupRun > DateTime.UtcNow.AddHours(-1))
         {
             return Task.CompletedTask;
         }
@@ -98,10 +98,10 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
         }
         return Task.Run(() =>
         {
-            _lastCleanupRun = DateTime.Now;
+            _lastCleanupRun = DateTime.UtcNow;
 
             logger.StartCleanupGames();
-            var currentTime = DateTime.Now;
+            var currentTime = DateTime.UtcNow;
             var gamesToRemove = _games.Values.Where(g => g.StartTime <= currentTime.AddHours(-3)).ToList();
             int gamesRemoved = 0;
             foreach (var game in gamesToRemove)

--- a/ch13/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch13/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -21,17 +21,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch13/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch13/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -84,7 +84,7 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
 
     private Task CleanupOldGamesAsync()
     {
-        if (_lastCleanupRun > DateTime.Now.AddHours(-1))
+        if (_lastCleanupRun > DateTime.UtcNow.AddHours(-1))
         {
             return Task.CompletedTask;
         }
@@ -98,10 +98,10 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
         }
         return Task.Run(() =>
         {
-            _lastCleanupRun = DateTime.Now;
+            _lastCleanupRun = DateTime.UtcNow;
 
             logger.StartCleanupGames();
-            var currentTime = DateTime.Now;
+            var currentTime = DateTime.UtcNow;
             var gamesToRemove = _games.Values.Where(g => g.StartTime <= currentTime.AddHours(-3)).ToList();
             int gamesRemoved = 0;
             foreach (var game in gamesToRemove)

--- a/ch14/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch14/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -21,17 +21,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch14/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch14/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -84,7 +84,7 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
 
     private Task CleanupOldGamesAsync()
     {
-        if (_lastCleanupRun > DateTime.Now.AddHours(-1))
+        if (_lastCleanupRun > DateTime.UtcNow.AddHours(-1))
         {
             return Task.CompletedTask;
         }
@@ -98,10 +98,10 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
         }
         return Task.Run(() =>
         {
-            _lastCleanupRun = DateTime.Now;
+            _lastCleanupRun = DateTime.UtcNow;
 
             logger.StartCleanupGames();
-            var currentTime = DateTime.Now;
+            var currentTime = DateTime.UtcNow;
             var gamesToRemove = _games.Values.Where(g => g.StartTime <= currentTime.AddHours(-3)).ToList();
             int gamesRemoved = 0;
             foreach (var game in gamesToRemove)

--- a/ch15/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch15/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -21,17 +21,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch15/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch15/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -84,7 +84,7 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
 
     private Task CleanupOldGamesAsync()
     {
-        if (_lastCleanupRun > DateTime.Now.AddHours(-1))
+        if (_lastCleanupRun > DateTime.UtcNow.AddHours(-1))
         {
             return Task.CompletedTask;
         }
@@ -98,10 +98,10 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
         }
         return Task.Run(() =>
         {
-            _lastCleanupRun = DateTime.Now;
+            _lastCleanupRun = DateTime.UtcNow;
 
             logger.StartCleanupGames();
-            var currentTime = DateTime.Now;
+            var currentTime = DateTime.UtcNow;
             var gamesToRemove = _games.Values.Where(g => g.StartTime <= currentTime.AddHours(-3)).ToList();
             int gamesRemoved = 0;
             foreach (var game in gamesToRemove)

--- a/ch16/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
+++ b/ch16/Codebreaker.GameAPIs.Tests/GamesServiceTests.cs
@@ -21,17 +21,17 @@ public class GamesServiceTests
 
     public GamesServiceTests()
     {
-        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _endedGame = new(_endedGameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()
             {
                 { FieldCategories.Colors, ["Red", "Green", "Blue", "Yellow", "Purple", "Orange"] }
             },
-            EndTime = DateTime.Now.AddMinutes(3)
+            EndTime = DateTime.UtcNow.AddMinutes(3)
         };
 
-        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.Now, 4, 12)
+        _running6x4Game = new(_running6x4GameId, "Game6x4", "Test", DateTime.UtcNow, 4, 12)
         {
             Codes = ["Red", "Green", "Blue", "Yellow"],
             FieldValues = new Dictionary<string, IEnumerable<string>>()

--- a/ch16/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
+++ b/ch16/Codebreaker.GameAPIs/Data/GamesMemoryRepository.cs
@@ -84,7 +84,7 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
 
     private Task CleanupOldGamesAsync()
     {
-        if (_lastCleanupRun > DateTime.Now.AddHours(-1))
+        if (_lastCleanupRun > DateTime.UtcNow.AddHours(-1))
         {
             return Task.CompletedTask;
         }
@@ -98,10 +98,10 @@ public partial class GamesMemoryRepository(ILogger<GamesMemoryRepository> logger
         }
         return Task.Run(() =>
         {
-            _lastCleanupRun = DateTime.Now;
+            _lastCleanupRun = DateTime.UtcNow;
 
             logger.StartCleanupGames();
-            var currentTime = DateTime.Now;
+            var currentTime = DateTime.UtcNow;
             var gamesToRemove = _games.Values.Where(g => g.StartTime <= currentTime.AddHours(-3)).ToList();
             int gamesRemoved = 0;
             foreach (var game in gamesToRemove)


### PR DESCRIPTION
##### PR Classification
Code cleanup to improve time consistency across the application.

#### PR Summary
This pull request updates the usage of `DateTime.Now` to `DateTime.UtcNow` in various classes to ensure consistent time handling in UTC. 
- **GamesFactory.cs**: Changed game instance creation to use `DateTime.UtcNow`.
- **GamesService.cs**: Updated game end time to `DateTime.UtcNow`.
- **GamesServiceTests.cs**: Modified test cases to reflect the use of `DateTime.UtcNow`.
- **GamesMemoryRepository.cs**: Adjusted cleanup logic and last cleanup run time to use `DateTime.UtcNow`.
